### PR TITLE
Enable mbedtls_psa_inject_entropy()

### DIFF
--- a/mbedtls_user_config.h
+++ b/mbedtls_user_config.h
@@ -26,7 +26,8 @@
  * building for an SPE. */
 #if defined(COMPONENT_PSA_SRV_IMPL) || defined(COMPONENT_PSA_SRV_EMUL)
 #   define MBEDTLS_ENTROPY_NV_SEED
-#   define MBEDTLS_PSA_HAS_ITS_IO
+#   define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+#   define MBEDTLS_PSA_INJECT_ENTROPY
 #   define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbed_default_seed_read
 #   define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbed_default_seed_write
 #endif


### PR DESCRIPTION
Enable mbedtls_psa_inject_entropy() by setting both
MBEDTLS_PSA_INJECT_ENTROPY and MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES, as
MBEDTLS_PSA_INJECT_ENTROPY is not compatible with actual entropy
sources.