### PR TITLE
Updating mbed-os to mbed-os-5.13.0-rc2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e0c7e087de858fd9c88703edf325705583c9939a
+https://github.com/ARMmbed/mbed-os/#cd8e315ba5875cf5af9f0489eb95b67f1b554fce


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.13.0-rc2 . 