### PR TITLE
Revert "Remove MBEDTLS_ENTROPY_NV_SEED and MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES"

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -57,6 +57,25 @@ int main(void)
 
 #define PSA_ATTESTATION_PRIVATE_KEY_ID 17
 
+static const uint8_t private_key_data[] = {
+    0x49, 0xc9, 0xa8, 0xc1, 0x8c, 0x4b, 0x88, 0x56,
+    0x38, 0xc4, 0x31, 0xcf, 0x1d, 0xf1, 0xc9, 0x94,
+    0x13, 0x16, 0x09, 0xb5, 0x80, 0xd4, 0xfd, 0x43,
+    0xa0, 0xca, 0xb1, 0x7d, 0xb2, 0xf1, 0x3e, 0xee
+};
+
+static const uint8_t public_key_data[] = {
+    0x04, 0x77, 0x72, 0x65, 0x6f, 0x81, 0x4b, 0x39,
+    0x92, 0x79, 0xd5, 0xe1, 0xf1, 0x78, 0x1f, 0xac,
+    0x6f, 0x09, 0x9a, 0x3c, 0x5c, 0xa1, 0xb0, 0xe3,
+    0x53, 0x51, 0x83, 0x4b, 0x08, 0xb6, 0x5e, 0x0b,
+    0x57, 0x25, 0x90, 0xcd, 0xaf, 0x8f, 0x76, 0x93,
+    0x61, 0xbc, 0xf3, 0x4a, 0xcf, 0xc1, 0x1e, 0x5e,
+    0x07, 0x4e, 0x84, 0x26, 0xbd, 0xde, 0x04, 0xbe,
+    0x6e, 0x65, 0x39, 0x45, 0x44, 0x96, 0x17, 0xde,
+    0x45
+};
+
 #define TEST_TOKEN_SIZE (0x200)
 #define TEST_CHALLENGE_OBJ_SIZE (32u)
 
@@ -73,14 +92,14 @@ static psa_status_t check_initial_attestation_get_token()
 {
     psa_status_t status = PSA_SUCCESS;
     size_t exported_length;
-    uint8_t exported[PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(256)];
+    uint8_t exported[sizeof(public_key_data)];
     enum psa_attest_err_t attest_err = PSA_ATTEST_ERR_SUCCESS;
     uint32_t token_size;
 
     status = psa_crypto_init();
     ASSERT_STATUS(status, PSA_SUCCESS);
-    status = psa_attestation_inject_key(NULL,
-                                        0,
+    status = psa_attestation_inject_key(private_key_data,
+                                        sizeof(private_key_data),
                                         PSA_KEY_TYPE_ECC_KEYPAIR(PSA_ECC_CURVE_SECP256R1),
                                         exported,
                                         sizeof(exported),
@@ -117,10 +136,40 @@ static void attestation_example(void)
     }
 }
 
+static void fake_set_initial_nvseed(void)
+{
+    /* This function, fake_set_initial_nvseed(), is useless on platforms that
+     * have already been manufactured correctly. This function demonstrates
+     * what a factory tool may do in order to manufacture a device that does
+     * not have its own source of entropy. */
+
+    /* mbedtls_psa_inject_entropy() is always present, but calls to it will
+     * always fail unless the PSA Secure Processing Element (SPE) is configured
+     * with both MBEDTLS_ENTROPY_NV_SEED and MBEDTLS_PSA_HAS_ITS_IO by the
+     * SPE's Mbed TLS configuration system. */
+    uint8_t seed[MBEDTLS_ENTROPY_MAX_SEED_SIZE];
+
+    /* Calculate a fake seed for injecting. A real factory application would
+     * inject true entropy for use as the initial NV Seed. */
+    for (size_t i = 0; i < sizeof(seed); ++i) {
+        seed[i] = i;
+    }
+
+    int status = mbedtls_psa_inject_entropy(seed, sizeof(seed));
+    if (status) {
+        /* The device may already have an NV Seed injected, or another error
+         * may have happened during injection. */
+        mbedtls_printf("warning (%d) - this attempt at entropy injection"
+                       " failed\n", status);
+    }
+}
+
 int main(void)
 {
     const psa_key_id_t key_id = PSA_ATTESTATION_PRIVATE_KEY_ID;
     psa_key_handle_t handle = 0;
+
+    fake_set_initial_nvseed();
     
     attestation_example();
 

--- a/mbedtls_user_config.h
+++ b/mbedtls_user_config.h
@@ -25,6 +25,8 @@
 /* Enable the default implementation of the PSA entropy injection API if we are
  * building for an SPE. */
 #if defined(COMPONENT_PSA_SRV_IMPL) || defined(COMPONENT_PSA_SRV_EMUL)
+#   define MBEDTLS_ENTROPY_NV_SEED
+#   define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
 #   define MBEDTLS_PSA_INJECT_ENTROPY
 #   define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbed_default_seed_read
 #   define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbed_default_seed_write


### PR DESCRIPTION
Reverts ARMmbed/mbed-os-example-attestation#22

To unblock Mbed OS master today. As there's bank holiday in UK, we might need this revert here on master later today.