### PR TITLE
Fix a missing header for GCC_ARM build with "-flto"

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+#include "mbed.h"
 #include "psa_initial_attestation_api.h"
 #include "psa_attest_inject_key.h"
 #include <stdlib.h>


### PR DESCRIPTION
Add the "mbed.h" header to use the MBED_USED attribute with main().
Without the attribute, the main() symbol is not emitted with the GCC
toolchain using "-Wl,--wrap,main" and "-flto" flags.

This patch is required by https://github.com/ARMmbed/mbed-os/pull/11856.