### PR TITLE
Enable experimental api for attestation example

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -3,6 +3,7 @@
         "*": {
              "platform.stdio-convert-newlines": true,
              "target.extra_labels_add": ["PSA"],
+             "target.features_add" : ["EXPERIMENTAL_API"],
              "target.components_remove": ["SD"]
         }
     },


### PR DESCRIPTION
PSA Crypto is being marked as experimental. As this example depends on PSA Crypto, we need to enable the EXPERIMENTAL_API feature in order to use it.