### PR TITLE
Remove deprecated function from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}


### PR DESCRIPTION
`mbed_set_mbed_target_linker_script` was removed from mbed-os.

This PR depends on https://github.com/ARMmbed/mbed-os/pull/14199