### PR TITLE
Update for mbed-os-6.10.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c73413893fb98aaaeda74513c981ac68adc8645d
+https://github.com/ARMmbed/mbed-os/#9738b27c7df897c29e9769911d6794ba3e5b3f19


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.10.0 release of mbed-os. 